### PR TITLE
Add publish GHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: main
+
+name: Quarto Publish
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Render and Publish
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,6 +3,9 @@ project:
   render:
     - "*.qmd"
 
+execute: 
+  freeze: auto
+
 website:
   draft-mode: unlinked
   title: "UoB RUG"


### PR DESCRIPTION
Add a GitHub Action to publish on a push to `main`.

Note that the website should be rendered locally with `quarto render` before pushing, and that if a `_freeze` directory is created or modified (this will happen when any of the `.qmd` pages have executable code chunks), that must be pushed to GitHub, or the action will fail. 